### PR TITLE
Resolve rpds-py depdency conflict

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - hatch-jupyter-builder
   run:
     - python >=3.8
+    - rpds-py ==0.27.1
     - jupyterlab-lsp ==5.0.*
     - diskcache ==5.6.*
     - jupyter_server


### PR DESCRIPTION
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

It should fix build failures `amazon-sagemaker-sql-editor 0.1.20 has requirement rpds-py==0.27.1, but you have rpds-py 0.30.0.`
